### PR TITLE
Take 'ng' out of the yotube composite operation

### DIFF
--- a/etc/workflows/partial-publish.xml
+++ b/etc/workflows/partial-publish.xml
@@ -432,7 +432,7 @@
       description="Create YouTube compatible output"
       if="${publishToYouTube}"
       fail-on-error="true"
-      exception-handler-workflow="ng-partial-error">
+      exception-handler-workflow="partial-error">
       <configurations>
         <configuration key="source-flavor-lower">presentation/themed</configuration>
         <configuration key="source-flavor-upper">presenter/themed</configuration>


### PR DESCRIPTION
- remove ng- prefix from exception-handler-workflow
- MH-12603 Take 'ng' out of the workflow filenames